### PR TITLE
Fix mainClass for javafx plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
                         <!-- Default configuration for running with: mvn clean javafx:run -->
                         <id>default-cli</id>
                         <configuration>
-                            <mainClass>org.bymc.gomoku/org.bymc.gomoku.HelloApplication</mainClass>
+                            <mainClass>org.bymc.gomoku/org.bymc.gomoku.ApplicationKt</mainClass>
                             <launcher>app</launcher>
                             <jlinkZipName>app</jlinkZipName>
                             <jlinkImageName>app</jlinkImageName>


### PR DESCRIPTION
## Summary
- update `pom.xml` to point to the correct Kotlin entrypoint `ApplicationKt`

## Testing
- `mvn javafx:run` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864e0958660832999a9624cdd55b6ad