### PR TITLE
Rename test method

### DIFF
--- a/src/test/kotlin/org/bymc/gomoku/model/impl/BoardImplTest.kt
+++ b/src/test/kotlin/org/bymc/gomoku/model/impl/BoardImplTest.kt
@@ -40,7 +40,7 @@ internal class BoardImplTest {
     }
 
     @Test
-    fun getSize_exceptional() {
+    fun getCell_exceptional() {
 
         val board = BoardImpl(Size2D(15, 15), setOf(Drop(Location2D(0, 0), Stone.WHITE)))
         assertThrows(RuntimeException::class.java) {


### PR DESCRIPTION
## Summary
- rename `getSize_exceptional` test to `getCell_exceptional`

## Testing
- `mvn -q test` *(fails: Could not transfer artifact kotlin-maven-plugin: network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6864e2e86ef8832986e63c664da49950